### PR TITLE
Add `from_slice` and `from_reader` helper fn's

### DIFF
--- a/third_party/src/error.rs
+++ b/third_party/src/error.rs
@@ -47,6 +47,18 @@ impl From<pest::error::Error<Rule>> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::Message { msg: err.to_string(), location: None}
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Error::Message { msg: err.to_string(), location: None}
+    }
+}
+
 impl ser::Error for Error {
     fn custom<T: Display>(msg: T) -> Self {
         Error::Message { msg: msg.to_string(), location: None }

--- a/third_party/src/lib.rs
+++ b/third_party/src/lib.rs
@@ -122,6 +122,6 @@ mod de;
 mod error;
 mod ser;
 
-pub use crate::de::from_str;
+pub use crate::de::{from_str, from_slice, from_reader};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::to_string;

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -758,3 +758,43 @@ fn deserializes_parse_error() {
         make_error("invalid type: integer `42`, expected a boolean", 2, 2),
     );
 }
+
+#[test]
+fn test_from_str() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct S {
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+
+    let data = "{ a: 5, b: 4, c: 3}";
+    assert_eq!(serde_json5::from_str(data), Ok(S{ a: 5, b:4, c:3}))
+}
+
+#[test]
+fn test_from_slice() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct S {
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+
+    let data = "{ a: 5, b: 4, c: 3}".as_bytes();
+    assert_eq!(serde_json5::from_slice(data), Ok(S{ a: 5, b:4, c:3}))
+}
+
+#[test]
+fn test_from_reader() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct S {
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+
+    let data = "{ a: 5, b: 4, c: 3}";
+    let mut reader = std::io::Cursor::new(data);
+    assert_eq!(serde_json5::from_reader(&mut reader), Ok(S{ a: 5, b:4, c:3}))
+}


### PR DESCRIPTION
This adds the helper fn's `from_slice` and `from_reader` to match those provided by serde_json, to handle similar use-cases.