### PR TITLE
Extend the public interface with Deserializer

### DIFF
--- a/third_party/src/de.rs
+++ b/third_party/src/de.rs
@@ -174,14 +174,14 @@ where
 }
 
 
-struct Deserializer<'de> {
+pub struct Deserializer<'de> {
     pair: Option<Pair<'de, Rule>>,
 }
 
 impl<'de> Deserializer<'de> {
     /// Creates a JSON5 deserializer from a `&str`. This parses the input at construction time, so
     /// can fail if the input is not valid JSON5.
-    fn from_str(input: &'de str) -> Result<Self> {
+    pub fn from_str(input: &'de str) -> Result<Self> {
         let pair = Parser::parse(Rule::text, input)?.next().unwrap();
         Ok(Deserializer::from_pair(pair))
     }

--- a/third_party/src/lib.rs
+++ b/third_party/src/lib.rs
@@ -122,6 +122,6 @@ mod de;
 mod error;
 mod ser;
 
-pub use crate::de::{from_str, from_slice, from_reader};
+pub use crate::de::{from_str, from_slice, from_reader, Deserializer};
 pub use crate::error::{Error, Location, Result};
 pub use crate::ser::to_string;


### PR DESCRIPTION
If there was an error while matching the parsed data with the defined struct, the path `a.b.c[0]` may be returned. One could use [`serde_path_to_error`](https://docs.rs/serde_path_to_error/latest/serde_path_to_error/) crate for that, but it requires access to the `Deserializer`. This PR is for that.

```rust
    #[derive(Deserialize)]
    struct Data { a: String };

    let j = r#"{ b: 42 }"#;

    // Some Deserializer.
    let jd = &mut serde_json5::Deserializer::from_str(j)?;

    let result: Result<Package, _> = serde_path_to_error::deserialize(jd);
    match result {
        Ok(_) => panic!("expected a type error"),
        Err(err) => {
            let path = err.path().to_string();
            println!("{}", path);
        }
    }
```