### PR TITLE
Fix deserialization of unit variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json5"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Gary Bressler <geb@google.com>"]
 description = "A Serde (de)serializer for JSON5."
 license = "Apache-2.0"

--- a/third_party/src/de.rs
+++ b/third_party/src/de.rs
@@ -598,7 +598,11 @@ impl<'de> de::VariantAccess<'de> for Variant<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
-        Ok(())
+        if let Some(pair) = self.pair {
+            serde::Deserialize::deserialize(&mut Deserializer::from_pair(pair))
+        } else {
+            Ok(())
+        }
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>

--- a/third_party/tests/common.rs
+++ b/third_party/tests/common.rs
@@ -1,4 +1,3 @@
-use matches::assert_matches;
 use serde_json5::{Error, Location};
 
 #[allow(unused)]
@@ -6,17 +5,17 @@ pub fn deserializes_to<'a, T>(s: &'a str, v: T)
 where
     T: ::std::fmt::Debug + ::std::cmp::PartialEq + serde::de::Deserialize<'a>,
 {
-    assert_matches!(serde_json5::from_str::<T>(s), Ok(value) if value == v);
+    assert_eq!(serde_json5::from_str::<T>(s), Ok(v));
 }
 
 #[allow(unused)]
 pub fn deserializes_to_nan_f32(s: &str) {
-    assert_matches!(serde_json5::from_str::<f32>(s), Ok(value) if value.is_nan());
+    assert!(serde_json5::from_str::<f32>(s).unwrap().is_nan());
 }
 
 #[allow(unused)]
 pub fn deserializes_to_nan_f64(s: &str) {
-    assert_matches!(serde_json5::from_str::<f64>(s), Ok(value) if value.is_nan());
+    assert!(serde_json5::from_str::<f64>(s).unwrap().is_nan());
 }
 
 #[allow(unused)]
@@ -24,7 +23,7 @@ pub fn deserializes_with_error<'a, T>(s: &'a str, error_expected: Error)
 where
     T: ::std::fmt::Debug + ::std::cmp::PartialEq + serde::de::Deserialize<'a>,
 {
-    assert_matches!(serde_json5::from_str::<T>(s), Err(e) if e == error_expected);
+    assert_eq!(serde_json5::from_str::<T>(s), Err(error_expected));
 }
 
 #[allow(unused)]

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -722,6 +722,8 @@ fn deserializes_enum_error() {
 
     deserializes_with_error::<S>("{ e: 'A' }", make_error("expected an object", 1, 6));
     deserializes_with_error::<S>("{ e: 'B' }", make_error("expected an array", 1, 6));
+    deserializes_with_error::<S>("{ e: { 'A': 5 } }", make_error("expected an object", 1, 6));
+    deserializes_with_error::<S>("{ e: { 'B': 5 } }", make_error("expected an array", 1, 6));
     deserializes_with_error::<E>(
         "\n 'C'",
         make_error("unknown variant `C`, expected `A` or `B`", 2, 2),

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -699,6 +699,7 @@ fn deserializes_enum() {
     }
 
     deserializes_to("'A'", E::A);
+    deserializes_to("{ A: null }", E::A);
     deserializes_to("{ B: 2 }", E::B(2));
     deserializes_to("{ C: [3, 5] }", E::C(3, 5));
     deserializes_to("{ D: { a: 7, b: 11 } }", E::D { a: 7, b: 11 });

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -713,6 +713,7 @@ fn deserializes_enum_error() {
     enum E {
         A {},
         B(),
+        C,
     }
 
     #[derive(Deserialize, PartialEq, Debug)]
@@ -724,9 +725,11 @@ fn deserializes_enum_error() {
     deserializes_with_error::<S>("{ e: 'B' }", make_error("expected an array", 1, 6));
     deserializes_with_error::<S>("{ e: { 'A': 5 } }", make_error("expected an object", 1, 6));
     deserializes_with_error::<S>("{ e: { 'B': 5 } }", make_error("expected an array", 1, 6));
+    deserializes_with_error::<S>("{ e: { 'C': 5 } }", make_error("invalid type: integer `5`, expected unit", 1, 13));
+    deserializes_with_error::<S>("{ e: { 'C': {} } }", make_error("invalid type: map, expected unit", 1, 13));
     deserializes_with_error::<E>(
-        "\n 'C'",
-        make_error("unknown variant `C`, expected `A` or `B`", 2, 2),
+        "\n 'D'",
+        make_error("unknown variant `D`, expected one of `A`, `B`, `C`", 2, 2),
     );
 }
 

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -725,8 +725,14 @@ fn deserializes_enum_error() {
     deserializes_with_error::<S>("{ e: 'B' }", make_error("expected an array", 1, 6));
     deserializes_with_error::<S>("{ e: { 'A': 5 } }", make_error("expected an object", 1, 6));
     deserializes_with_error::<S>("{ e: { 'B': 5 } }", make_error("expected an array", 1, 6));
-    deserializes_with_error::<S>("{ e: { 'C': 5 } }", make_error("invalid type: integer `5`, expected unit", 1, 13));
-    deserializes_with_error::<S>("{ e: { 'C': {} } }", make_error("invalid type: map, expected unit", 1, 13));
+    deserializes_with_error::<S>(
+        "{ e: { 'C': 5 } }",
+        make_error("invalid type: integer `5`, expected unit", 1, 13),
+    );
+    deserializes_with_error::<S>(
+        "{ e: { 'C': {} } }",
+        make_error("invalid type: map, expected unit", 1, 13),
+    );
     deserializes_with_error::<E>(
         "\n 'D'",
         make_error("unknown variant `D`, expected one of `A`, `B`, `C`", 2, 2),


### PR DESCRIPTION
`serde_json` allows for deserializing a unit variant like:
    
```
enum SomeEnum {
    SomeVariant
}
```
    
from either a string like `"SomeVariant"` or `{"SomeVariant: null}`. Previously `serde_json5` would allow for any value in the second case. That data would then be thrown away. This changes `serde_json5` to match `serde_json` and only allow `null`.

Note that this is a breaking change, and so it bumps the version.