### PR TITLE
Change serde_json5::from_reader to match serde_json

### DIFF
--- a/third_party/src/de.rs
+++ b/third_party/src/de.rs
@@ -162,7 +162,7 @@ where
 
 /// Deserialize an instance of type `T` from any implementation of Read.  Can fail if the input is
 /// invalid JSON5, or doesn&rsquo;t match the structure of the target type.
-pub fn from_reader<T, R>(reader: &mut R) -> Result<T>
+pub fn from_reader<R, T>(mut reader: R) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
     R: Read,


### PR DESCRIPTION
Serde implements `DeserializeOwned` on `&T`, so passing in the reader as `&mut R` is redundant.

This changes the typaram to match serde_json, so it's a breaking change.

Closes #4.