### PR TITLE
Fix IEEE754 value parsing in deserialize_any

### DIFF
--- a/third_party/src/de.rs
+++ b/third_party/src/de.rs
@@ -471,7 +471,12 @@ fn parse_integer(pair: &Pair<'_, Rule>) -> Result<i64> {
 }
 
 fn is_int(s: &str) -> bool {
-    !s.contains('.') && (is_hex_literal(s) || (!s.contains('e') && !s.contains('E')))
+    !s.contains('.')
+        && (is_hex_literal(s)
+            || (!s.contains('e')
+                && !s.contains('E')
+                && !s.contains("Infinity")
+                && !s.contains("NaN")))
 }
 
 fn parse_hex(s: &str) -> Result<u32> {


### PR DESCRIPTION
The Infinities and NaN's do not de-serialize correctly when `deserialize_any` is invoked due to `is_int` not checking for those values. Currently these values are parsed as i64's causing errors.

Should close https://github.com/google/serde_json5/issues/14

The test cases were my minimum recreations for getting `deserialize_any` to invoke, let me know if they can be made more condensed.