### PR TITLE
Support to_writer

### DIFF
--- a/third_party/src/de.rs
+++ b/third_party/src/de.rs
@@ -136,7 +136,6 @@ unicode_letter = _{
 
 value = _{ null | boolean | string | number | object | array }
 "#]
-
 struct Parser;
 
 /// Deserialize an instance of type `T` from a string of JSON5 text. Can fail if the input is
@@ -191,7 +190,7 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>

--- a/third_party/src/error.rs
+++ b/third_party/src/error.rs
@@ -59,6 +59,15 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(err: std::string::FromUtf8Error) -> Self {
+        Error::Message {
+            msg: err.to_string(),
+            location: None,
+        }
+    }
+}
+
 impl From<std::str::Utf8Error> for Error {
     fn from(err: std::str::Utf8Error) -> Self {
         Error::Message {

--- a/third_party/src/lib.rs
+++ b/third_party/src/lib.rs
@@ -100,7 +100,7 @@
 //! - serializing or deserializing [byte arrays][]
 //!
 //! - specifying the style of JSON5 output from the serializer (single over double quotes, trailing
-//! commas, indentation etc.)
+//!   commas, indentation etc.)
 //!
 //! [JSON]: https://tools.ietf.org/html/rfc7159
 //! [ECMAScript 5.1]: https://www.ecma-international.org/ecma-262/5.1/
@@ -124,4 +124,4 @@ mod ser;
 
 pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
 pub use crate::error::{Error, Location, Result};
-pub use crate::ser::to_string;
+pub use crate::ser::{to_string, to_writer};

--- a/third_party/tests/de.rs
+++ b/third_party/tests/de.rs
@@ -393,7 +393,7 @@ fn deserializes_unit_error() {
             D: de::Deserializer<'de>,
         {
             struct Visitor;
-            impl<'de> de::Visitor<'de> for Visitor {
+            impl de::Visitor<'_> for Visitor {
                 type Value = A;
                 fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     f.write_str("...")

--- a/third_party/tests/ser.rs
+++ b/third_party/tests/ser.rs
@@ -233,3 +233,19 @@ fn serializes_enum() {
     serializes_to!(E::C(3, 5), "{\"C\":[3,5]}");
     serializes_to!(E::D { a: 7, b: 11 }, "{\"D\":{\"a\":7,\"b\":11}}");
 }
+
+#[test]
+fn test_to_writer() {
+    #[derive(Serialize)]
+    struct S {
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+
+    let value = S { a: 5, b: 4, c: 3 };
+    let mut writer = Vec::<u8>::new();
+    serde_json5::to_writer(&mut writer, &value).expect("to_writer succeeds");
+    let data = std::str::from_utf8(&writer).expect("valid utf8");
+    assert_eq!(data, r#"{"a":5,"b":4,"c":3}"#);
+}


### PR DESCRIPTION
Refactors the Serializer to bring support for `to_writer` in addition to `to_string`.